### PR TITLE
Allow developers to set height and width dynamically

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
     <script>
       document.addEventListener("DOMContentLoaded", () => {
         const editor = MaxiEditor.create("#editor", {
+          height: "400px",
+          width: "800px",
           toolbar: [
             "bold",
             "italic",

--- a/maxi-editor.css
+++ b/maxi-editor.css
@@ -9,30 +9,13 @@ body {
 }
 
 .editor-container {
-    width: 70%;
-    max-width: 900px;
+    width: auto;
+    max-width: auto;
     text-align: left;
-}
-
-.editor {
-    border: 1px solid #ccc;
-    padding: 10px;
-    min-height: 300px;
-    font-size: 16px;
-    font-family: Arial, sans-serif;
-    background-color: #fff;
 }
 
 .maxi-toolbar {
     display: flex;
-    /* gap: 10px; */
-    /* background-color: #f4f4f4; */
-    /* padding: 10px; */
-    /* border-bottom: 1px solid #ccc; */
-    /* border-radius: 5px 5px 0 0; */
-    /* box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1); */
-    /* margin-bottom: 10px; */
-
     flex-wrap: wrap;
     justify-content: left;
     margin-bottom: 3px;
@@ -74,8 +57,8 @@ select {
 .maxi-editor {
     border: 1px solid #ddd;
     padding: 10px;
-    min-height: 200px;
-    max-height: 300px;
     overflow-y: auto;
     font-family: Arial, sans-serif;
+    height: auto;
+    background-color: #fff;
 }

--- a/maxi-editor.js
+++ b/maxi-editor.js
@@ -10,6 +10,7 @@ class MaxiEditor {
     constructor(element, config) {
         this.element = element;
         this.config = config;
+        this.height = config.height || '300px';
         this.commands = {};
         this.state = {};
 
@@ -60,12 +61,10 @@ class MaxiEditor {
             this.applyPlugins(this.config.plugins);
         }
 
+
         // Track selection changes to update toolbar state (make the toolbar item active or inactive)
         this.trackSelection();
     }
-
-
-
 
     /**
      * Creates the toolbar panel for the MaxiEditor instance.
@@ -271,6 +270,24 @@ class MaxiEditor {
     }
 
     /**
+       * Sets the height of the editor dynamically.
+       * 
+       * @param {string} height - The desired height (e.g., '500px').
+       */
+    setHeight(height) {
+        this.element.style.height = height;
+    }
+
+    /**
+       * Sets the width of the editor dynamically.
+       * 
+       * @param {string} width - The desired width (e.g., '200px').
+       */
+    setHeight(width) {
+        this.element.style.width = width;
+    }
+
+    /**
      * Creates a new MaxiEditor instance with the specified element and configuration.
      *
      * @param {string} selector - A CSS selector that identifies the element to be used as the editor.
@@ -283,6 +300,15 @@ class MaxiEditor {
         if (!element) {
             throw new Error('Editor element not found');
         }
+
+        if (config.height) {
+            editor.style.height = config.height;
+        }
+
+        if (config.width) {
+            editor.style.width = config.width;
+        }
+
         return new MaxiEditor(element, config);
     }
 }


### PR DESCRIPTION
```js
 document.addEventListener("DOMContentLoaded", () => {
   const editor = MaxiEditor.create("#editor", {
     height: "400px",
     width: "800px",
     toolbar: [
       "bold",
       "italic",
       "underline",
       "justifyLeft",
       "justifyCenter",
       "justifyRight",
       "insertUnorderedList",
       "insertOrderedList",
       "indent",
       "undo",
       "redo",
      ],
      plugins: [],
    });
 });
```